### PR TITLE
add Makefile for build/push in lieu of a good automated build solution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+TAGS=.latest .nvidia-cuda .opencl .virtualbox
+
+build:
+	for TAG in ${TAGS}; do \
+		docker build -t boinc/client:$${TAG#.}  -f Dockerfile$${TAG#.latest} . ; \
+	done
+
+push:
+	for TAG in ${TAGS}; do \
+		docker push boinc/client:$${TAG#.} ; \
+	done


### PR DESCRIPTION
Until Docker Cloud gets their act together, we just manually run `make build push` any time a commit is made. Thoughts? 