### PR TITLE
Removed the /dev/input/mice workaround.

### DIFF
--- a/bin/start-boinc.sh
+++ b/bin/start-boinc.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Workaround for activity checking which sends "Could not open directory '/dev/input/mice' from '/var/lib/boinc-client'" errors
-mkdir -p /dev/input/mice
-
 # Configure the GUI RPC
 echo $BOINC_GUI_RPC_PASSWORD > /var/lib/boinc-client/gui_rpc_auth.cfg
 echo $BOINC_REMOTE_HOST > /var/lib/boinc-client/remote_hosts.cfg


### PR DESCRIPTION
The version of BOINC (7.10.3) fixes the `/dev/input/mice` error, so the workaround in the `start-boinc.sh` no needed anymore.