### PR TITLE
Remove the DEBIAN_FRONTEND noninteractive environment variable. Setti…

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -4,8 +4,7 @@ LABEL maintainer="BOINC" \
       description="A lightweight BOINC client on ARMv7 32-bit architecture."
 
 # Global environment settings
-ENV DEBIAN_FRONTEND="noninteractive" \
-    BOINC_GUI_RPC_PASSWORD="123" \
+ENV BOINC_GUI_RPC_PASSWORD="123" \
     BOINC_REMOTE_HOST="127.0.0.1" \
     BOINC_CMD_LINE_OPTIONS=""
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -4,8 +4,7 @@ LABEL maintainer="BOINC" \
       description="A lightweight BOINC client on ARMv8 64-bit architecture."
 
 # Global environment settings
-ENV DEBIAN_FRONTEND="noninteractive" \
-    BOINC_GUI_RPC_PASSWORD="123" \
+ENV BOINC_GUI_RPC_PASSWORD="123" \
     BOINC_REMOTE_HOST="127.0.0.1" \
     BOINC_CMD_LINE_OPTIONS=""
 

--- a/Dockerfile.baseimage-ubuntu
+++ b/Dockerfile.baseimage-ubuntu
@@ -5,8 +5,7 @@ LABEL maintainer="BOINC" \
       boinc-version="7.14.2"
 
 # Global environment settings
-ENV DEBIAN_FRONTEND="noninteractive" \
-    BOINC_GUI_RPC_PASSWORD="123" \
+ENV BOINC_GUI_RPC_PASSWORD="123" \
     BOINC_REMOTE_HOST="127.0.0.1" \
     BOINC_CMD_LINE_OPTIONS=""
 

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -4,8 +4,7 @@ LABEL maintainer="BOINC" \
       description="NVIDIA-savvy (CUDA & OpenCL) BOINC client."
 
 # Global environment settings
-ENV DEBIAN_FRONTEND="noninteractive" \
-    BOINC_GUI_RPC_PASSWORD="123" \
+ENV BOINC_GUI_RPC_PASSWORD="123" \
     BOINC_REMOTE_HOST="127.0.0.1" \
     BOINC_CMD_LINE_OPTIONS=""
 


### PR DESCRIPTION
…ng it via ENV should be actively discouraged, because if I docker run -i -t ... bash, I'm now interactive, and this variable being set is very, very wrong, according to this issue: https://github.com/moby/moby/issues/4032.