### PR TITLE
Switch to boinccmd

### DIFF
--- a/bin/start-boinc.sh
+++ b/bin/start-boinc.sh
@@ -5,4 +5,4 @@ echo $BOINC_GUI_RPC_PASSWORD > /var/lib/boinc/gui_rpc_auth.cfg
 echo $BOINC_REMOTE_HOST > /var/lib/boinc/remote_hosts.cfg
 
 # Run BOINC. Full path needs for GPU support.
-exec /usr/bin/boinc $BOINC_CMD_LINE_OPTIONS
+exec /usr/bin/boinccmd $BOINC_CMD_LINE_OPTIONS


### PR DESCRIPTION
We are unable to pass arguments using the envar without encoutering errors. To circumvent this, running boinccmd instead of boinc seems to be the solution.

Logs:

> The command-line options for /usr/bin/boinc are intended for debugging.
> The recommended command-line interface is a separate program,'boinccmd'.
> Run boinccmd in the same directory as /usr/bin/boinc.