### PR TITLE
Enable cross-architecture builds

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -6,6 +6,9 @@
 # or `nvidia`) since those depend on the base one. 
 #
 
+# Enable builds across architectures (i.e. arm32v7 and arm64v8 on amd64)
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
 # Base images
 docker build -t boinc/client:base-alpine -f Dockerfile.base-alpine .
 docker build -t boinc/client:base-ubuntu -f Dockerfile.base-ubuntu .

--- a/update.sh
+++ b/update.sh
@@ -30,5 +30,16 @@ docker push boinc/client:multi-gpu
 docker build -t boinc/client:virtualbox -f Dockerfile.virtualbox .
 docker push boinc/client:virtualbox
 
+# Enable builds for other architectures (i.e. arm32v7, arm64v8)
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+# Arm32v7
+docker build -t boinc/client:arm32v7 -f Dockerfile.arm32v7 .
+docker push boinc/client:arm32v7
+
+# Arm64v8
+docker build -t boinc/client:arm64v8 -f Dockerfile.arm64v8 .
+docker push boinc/client:arm64v8
+
 # Remove all the docker images
 docker system prune -a

--- a/update.sh
+++ b/update.sh
@@ -34,11 +34,11 @@ docker push boinc/client:virtualbox
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 # Arm32v7
-docker build -t boinc/client:arm32v7 -f Dockerfile.arm32v7 .
+docker build --platform=linux/arm/v7 -t boinc/client:arm32v7 -f Dockerfile.arm32v7 .
 docker push boinc/client:arm32v7
 
 # Arm64v8
-docker build -t boinc/client:arm64v8 -f Dockerfile.arm64v8 .
+docker build --platform=linux/arm64/v8 -t boinc/client:arm64v8 -f Dockerfile.arm64v8 .
 docker push boinc/client:arm64v8
 
 # Remove all the docker images


### PR DESCRIPTION
Using multiarch/qemu-user-static allows for many cross-architecture build scenarios. In this case looking to enable builds of the arm32v7 and arm64v8 images on common amd64 platforms such as docker hubs build infrastructure. 