### PR TITLE
Installing `libgomp1` into the ARM 64 image

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -22,6 +22,8 @@ EXPOSE 31416
 RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Time Zone Database
 	tzdata \
+# libgomp1 is required by the project SiDock_At_Home
+	libgomp1 \
 # Install BOINC Client
     boinc-client && \
 # Cleaning up


### PR DESCRIPTION
The library `libcomp1` is required by the project `SiDock@Home`. Without this library, the computation will fail.

The [original error message from SiDock](https://www.sidock.si/sidock/result.php?resultid=71670915):

```
<core_client_version>7.12.0</core_client_version>
<![CDATA[
<message>
process exited with code 195 (0xc3, -61)</message>
<stderr_txt>
18:01:48 (60): wrapper (7.17.26016): starting
18:01:48 (60): wrapper (7.17.26016): starting
18:01:48 (60): wrapper: running cmdock (-c -r target.prm -p "/var/lib/boinc/slots/3/data/scripts/dock.prm" -f htvs.ptc -i ligands.sdf -o docking_out)
cmdock: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory
18:01:49 (60): cmdock exited; CPU time 0.001545
18:01:49 (60): app exit status: 0x7f
18:01:49 (60): called boinc_finish(195)

</stderr_txt>
]]>
```

Please help review and consider merging this PR. 

Thanks!
